### PR TITLE
Support alias/image dimension syntax conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ This plugin will convert the `.md` file and related images in obsidian to the hu
 
 Conversion includes:
 - `[[link.com]]` -> `[link.com](link.com)`
-- `[[xxx.png]]` -> `![xxx.png](/${static_dir}/xx.png)`
-- Auto write md's yaml header like: title,date,lastmod 
+- `[[link.com|alias-text]]` -> `[alias-text](link.com)`
+- `![[xxx.png]]` -> `![xxx.png](/${static_dir}/xx.png)`
+- `![[xxx.png|200*100]]` -> `![xxx.png](/${static_dir}/xx.png)`
+- Auto write md's yaml header like: title,date,lastmod
 
 ## How to use
 
@@ -16,4 +18,3 @@ Conversion includes:
 2. Set `tags` in obsidian's md as `${blog_tag}`
 3. Click `hugo sync` button or run cmd `Hugo Publish: Sync blog`
 4. Enter the hugo site dir to run `hugo server` to check it
-

--- a/src/util.ts
+++ b/src/util.ts
@@ -141,7 +141,7 @@ const transform_wiki_image_on_parent = (node: Parent) => {
         const child = node.children[i];
         if (child.type == "text") {
             const text = child.value.slice(); // clone
-            const regex = /!\[\[(.*?)\]\]/g;
+            const regex = /!\[\[([^|]+)(?:\|([^\]]+))?\]\]/g;
             let match;
             let last_index = 0;
             let after_text = text.slice();
@@ -183,12 +183,13 @@ const transform_wiki_link_on_parent = (node: Parent) => {
         const child = node.children[i];
         if (child.type == "text") {
             const text = child.value.slice(); // clone
-            const regex = /\[\[(.*?)\]\]/g;
+            const regex = /\[\[([^|]+)(?:\|([^\]]+))?\]\]/g;
             let match;
             let last_index = 0;
             let after_text = text.slice();
             while ((match = regex.exec(text)) != null) {
                 const link_text = match[1];
+                const alias = match[2];
                 const image_url = link_text;
 
                 const before_text = text.slice(last_index, match.index);
@@ -200,7 +201,7 @@ const transform_wiki_link_on_parent = (node: Parent) => {
                 }
                 const link_txt: Text = {
                     type: "text",
-                    value: image_url
+                    value: alias || link_text
                 };
                 const v: Link = {
                     type: 'link',


### PR DESCRIPTION
This PR makes two improvements:

1. Add support for file link alias syntax
2. Fix broken image URLs caused by [image dimension syntax](https://help.obsidian.md/syntax#External+images)

broken image URL example
<img width="435" height="42" alt="스크린샷 2026-01-22 오후 11 33 44" src="https://github.com/user-attachments/assets/6c84ef0f-901c-4115-84a6-b2421fb10f05" />

# Changes

- Modified to prioritize using alias text for file link names when it exists
- Ignore image demention syntax
