### PR TITLE
Wikilink path options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -249,6 +249,7 @@ export default class HugoPublishPlugin extends Plugin {
 									.map((segment: string) => segment
 										.toLowerCase()
 										.replace(/\s+/g, '-')
+										.replace(/[(),.]/g, '')
 									)
 									.join('/');
 							}

--- a/src/main.ts
+++ b/src/main.ts
@@ -229,26 +229,37 @@ export default class HugoPublishPlugin extends Plugin {
 						node.url = encodeURI(path.join("/", static_dir, vv).replace(/\\/g, '/'));
 					}
 				})
-				visit(ast, 'link', function (node, index, parent) {
+				visit(ast, 'link', function (node: any, index: any, parent: any) {
 					const decoded_url = decodeURI(node.url);
-					const v = link2path.get(decoded_url)
+					const v = link2path.get(decoded_url);
 					if (v) {
 						const [vv, is_md] = v;
 						if (is_md) {
-							// Slugify each path segment to match Hugo's URL format
-							const slugified = vv
-								.split('/')
-								.map((segment: string) => segment
-									.toLowerCase()
-									.replace(/\s+/g, '-')
-								)
-								.join('/');
-							node.url = encodeURI(path.join("/", slugified).replace(/\\/g, '/'));
+							let resolved = vv;
+
+							// apply slugification if enabled
+							if (this.settings.slugify_paths) {
+								resolved = resolved
+									.split('/')
+									.map((segment: string) => segment
+										.toLowerCase()
+										.replace(/\s+/g, '-')
+									)
+									.join('/');
+							}
+
+							// prepend content root if set
+							const root = this.settings.content_root.replace(/^\/|\/$/g, '');
+							if (root.length > 0) {
+								resolved = root + '/' + resolved;
+							}
+
+							node.url = encodeURI(path.join("/", resolved).replace(/\\/g, '/'));
 						} else {
 							node.url = encodeURI(path.join("/", static_dir, vv).replace(/\\/g, '/'));
 						}
 					}
-				})
+				}.bind(this))
 
 				// body = remark.stringify(ast);
 				body = toMarkdown(ast, { extensions: [mathToMarkdown(), gfmTableToMarkdown()] });

--- a/src/main.ts
+++ b/src/main.ts
@@ -225,13 +225,34 @@ export default class HugoPublishPlugin extends Plugin {
 
 				//console.log("this", this);
 				//console.log("link2path", link2path, "meta", meta)
-				visit(ast, 'image', function (node, index, parent) {
+				visit(ast, 'image', function (node: any, index: any, parent: any) {
 					const decoded_url = decodeURI(node.url);
 					const v = link2path.get(decoded_url)
 					if (v) {
 						// eslint-disable-next-line @typescript-eslint/no-unused-vars
 						const [vv, _is_md] = v;
-						node.url = encodeURI(path.join("/", static_dir, vv).replace(/\\/g, '/'));
+						const resolved_url = encodeURI(path.join("/", static_dir, vv).replace(/\\/g, '/'));
+
+						if (node.hugoFigure) {
+							// Convert to a raw Hugo figure shortcode
+							const width: string = node.figureWidth;
+							const height: string | null = node.figureHeight;
+							let shortcode = `{{< figure src="${resolved_url}" alt="${node.alt}"`;
+							if (width) shortcode += ` width="${width}"`;
+							if (height) shortcode += ` height="${height}"`;
+							shortcode += ` >}}`;
+							// Mutate in-place to an html node
+							node.type = 'html';
+							node.value = shortcode;
+							delete node.url;
+							delete node.alt;
+							delete node.title;
+							delete node.hugoFigure;
+							delete node.figureWidth;
+							delete node.figureHeight;
+						} else {
+							node.url = resolved_url;
+						}
 					}
 				})
 				visit(ast, 'link', function (node: any, index: any, parent: any) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,7 +211,12 @@ export default class HugoPublishPlugin extends Plugin {
 						const link_f = this.app.metadataCache.getFirstLinkpathDest(v.link, f.path);
 						if (link_f) {
 							if (link_f.path.endsWith(".md")) {
-								link2path.set(v.link, [v.link, true]);
+								if (this.settings.resolve_full_path) {
+									const resolved_path = link_f.path.replace(/\.md$/, "");
+									link2path.set(v.link, [resolved_path, true]);
+								} else {
+									link2path.set(v.link, [v.link, true]);
+								}
 							}
 						}
 					}

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -11,6 +11,8 @@ export interface HugoPublishSettings {
     blog_dir: string; // relative path to site_dir
     static_dir: string; // relative path to site_dir/static
     keep_list: string;
+    slugify_paths: boolean;
+    content_root: string;
     get_exclude_dir: () => string[];
     get_blog_abs_dir: () => string;
     get_static_abs_dir: () => string;
@@ -46,7 +48,9 @@ export const DEFAULT_SETTINGS: HugoPublishSettings = {
         }
         return regs;
     },
-    export_blog_tag: true
+    export_blog_tag: true,
+    slugify_paths: false,
+    content_root: ""
 }
 
 export class HugoPublishSettingTab extends PluginSettingTab {
@@ -102,6 +106,26 @@ export class HugoPublishSettingTab extends PluginSettingTab {
                 this.plugin.settings.keep_list = value;
                 await this.plugin.saveSettings();
             }));
+		new Setting(containerEl)
+			.setName("slugify paths")
+			.setDesc("Convert link paths to Hugo-compatible slugs (lowercase, spaces to hyphens). Enable if your Hugo site uses default permalink settings.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.slugify_paths)
+				.onChange(async (value) => {
+					this.plugin.settings.slugify_paths = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName("content root")
+			.setDesc("Prepend this path to all internal links. Use if your content lives in a subdirectory (e.g. 'post'). Leave empty if content is at site root.")
+			.addText(text => text
+				.setPlaceholder("post")
+				.setValue(this.plugin.settings.content_root)
+				.onChange(async (value) => {
+					this.plugin.settings.content_root = value;
+					await this.plugin.saveSettings();
+				}));
     }
 }
 

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -13,6 +13,7 @@ export interface HugoPublishSettings {
     keep_list: string;
     slugify_paths: boolean;
     content_root: string;
+    resolve_full_path: boolean;
     get_exclude_dir: () => string[];
     get_blog_abs_dir: () => string;
     get_static_abs_dir: () => string;
@@ -50,7 +51,8 @@ export const DEFAULT_SETTINGS: HugoPublishSettings = {
     },
     export_blog_tag: true,
     slugify_paths: false,
-    content_root: ""
+    content_root: "",
+    resolve_full_path: false
 }
 
 export class HugoPublishSettingTab extends PluginSettingTab {
@@ -124,6 +126,15 @@ export class HugoPublishSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.content_root)
 				.onChange(async (value) => {
 					this.plugin.settings.content_root = value;
+					await this.plugin.saveSettings();
+				}));
+		new Setting(containerEl)
+			.setName("resolve full path")
+			.setDesc("Resolve wikilinks to their full vault path instead of just the note name. Enable if your Hugo content is organized in subdirectories (e.g. post/my-note instead of my-note).")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.resolve_full_path)
+				.onChange(async (value) => {
+					this.plugin.settings.resolve_full_path = value;
 					await this.plugin.saveSettings();
 				}));
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -99,7 +99,7 @@ export const get_md_yaml_header_from_content = (content: string): [string, strin
         }
         return [header, body]
     } else {
-        // no hefader
+        // no header
         return ["", content]
     }
 }
@@ -115,6 +115,8 @@ export const transform_better_latex = (ast: Root) => {
 }
 
 // ![[xxx.png]] -> ![xxx.png](xxx.png)
+// ![[xxx.png|400]] -> {{< figure src="..." width="400" >}}
+// ![[xxx.png|640x480]] -> {{< figure src="..." width="640" height="480" >}}
 export const transform_wiki_image = (ast: Root) => {
     visit(ast, 'paragraph', function (node, index, parent) {
         transform_wiki_image_on_parent(node);
@@ -147,6 +149,7 @@ const transform_wiki_image_on_parent = (node: Parent) => {
             let after_text = text.slice();
             while ((match = regex.exec(text)) != null) {
                 const link_text = match[1];
+                const size_hint = match[2]; // e.g. "468" or "640x480"
                 const image_url = link_text;
 
                 const before_text = text.slice(last_index, match.index);
@@ -156,15 +159,32 @@ const transform_wiki_image_on_parent = (node: Parent) => {
                     const v: Text = { type: "text", value: before_text };
                     new_children.push(v);
                 }
-                const v: Image = {
-                    type: 'image',
-                    url: encodeURI(image_url),
-                    alt: image_url,
-                    title: null
-                };
-                new_children.push(v);
-                last_index = match.index + match[0].length;
 
+                if (size_hint && /^\d+(x\d+)?$/.test(size_hint.trim())) {
+                    // Has a numeric dimension hint — use hugoFigure flag so the
+                    // image visitor in main.ts can emit a figure shortcode after
+                    // resolving the final URL. Store width/height in the node.
+                    const parts = size_hint.trim().split('x');
+                    const v: any = {
+                        type: 'image',
+                        url: encodeURI(image_url),
+                        alt: image_url,
+                        title: null,
+                        hugoFigure: true,
+                        figureWidth: parts[0],
+                        figureHeight: parts[1] ?? null,
+                    };
+                    new_children.push(v);
+                } else {
+                    const v: Image = {
+                        type: 'image',
+                        url: encodeURI(image_url),
+                        alt: image_url,
+                        title: null
+                    };
+                    new_children.push(v);
+                }
+                last_index = match.index + match[0].length;
             }
             if (after_text.length > 0) {
                 const v: Text = { type: "text", value: after_text };


### PR DESCRIPTION
Context
Following the previous PR fixing wikilink path resolution, the core changes were reverted to preserve compatibility with existing setups and UTF-8 note titles. This PR reintroduces those fixes as opt-in settings, keeping the default behaviour unchanged.

New settings
resolve full path — when enabled, wikilinks resolve to their full vault path instead of just the note name. This is necessary when Hugo content is organized in subdirectories (e.g. post/serial-experiment-lain instead of just serial-experiment-lain). Default: false.
slugify paths — when enabled, converts each path segment to a Hugo-compatible slug: lowercase, spaces replaced with hyphens, and special characters (parentheses, commas etc.) stripped to match Hugo's own slug generation. Default: false.
content root — prepends a fixed path prefix to all internal links. Useful for setups where the vault is not already organized in subdirectories matching Hugo's content structure. Leave empty if vault paths already include the content directory. Default: "".
Bug fix
Fixed regex in transform_wiki_link_on_parent and transform_wiki_image_on_parent — changed [^|]+ to [^\]|]+ to prevent greedy matching past the first ]], which caused multiple wikilinks on the same line to merge into a single broken link.
Compatibility
All new settings default to false/"", preserving the existing behaviour for all current users. UTF-8 note titles (CJK, accented characters) are unaffected since the slugification only performs lowercase and hyphenation without stripping non-ASCII characters — matching Hugo's own default slug behaviour.